### PR TITLE
Hotfix

### DIFF
--- a/controller/GameManager.hpp
+++ b/controller/GameManager.hpp
@@ -6,6 +6,7 @@
 
 #include "../model/Item.hpp"
 #include "../model/Snake.hpp"
+#include "../model/Empty.hpp"
 #include "../view/Board.hpp"
 #include "../view/Drawable.hpp"
 


### PR DESCRIPTION
1. GameManager.hpp
   - Empty.hpp 파일을 include 하지 않아 발생하는 버그 해결.